### PR TITLE
[Design] 전체 페이지 높이 및 스크롤바 변경

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,8 @@ import { RouterProvider } from 'react-router-dom';
 import store from './redux/store/store';
 import { router } from './routes/routes';
 
+import './styles/_base.scss';
+
 export default function App() {
   return (
     <Provider store={store}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,6 @@
-import { RouterProvider } from 'react-router-dom';
 import { Provider } from 'react-redux';
+import { RouterProvider } from 'react-router-dom';
 import store from './redux/store/store';
-
 import { router } from './routes/routes';
 
 export default function App() {

--- a/src/hooks/useModal/useModal.tsx
+++ b/src/hooks/useModal/useModal.tsx
@@ -12,14 +12,12 @@ export const useModal = () => {
 
   // 모달을 열기 위한 함수
   const openModal = (name: string) => {
-    document.body.style.overflow = 'hidden';
     setModalName(name);
     document.addEventListener('mousedown', handleClickOutside);
   };
 
   // 모달을 닫기 위한 함수
   const closeModal = () => {
-    document.body.style.overflow = 'unset';
     setModalName('');
     document.removeEventListener('mousedown', handleClickOutside);
   };

--- a/src/routes/layout/index.tsx
+++ b/src/routes/layout/index.tsx
@@ -1,6 +1,7 @@
 import Footer from '@/components/Footer';
 import Header from '@/components/Header';
 import { Outlet } from 'react-router-dom';
+import './style.scss';
 
 export default function Layout() {
   return (

--- a/src/routes/layout/style.scss
+++ b/src/routes/layout/style.scss
@@ -1,0 +1,3 @@
+main {
+  flex-grow: 1;
+}

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -14,7 +14,6 @@ import MyPage from '@/pages/MyPage';
 import MyReservation from '@/pages/MyReservation';
 import EditSpace from '@/pages/EditSpace';
 import AddSpace from '@/pages/AddSpace';
-import '../styles/_base.scss';
 
 const PrimaryRoute = (
   <>

--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -53,6 +53,7 @@ html {
 body {
   font-family: 'Pretendard Variable', sans-serif;
   height: 100%;
+  overflow: hidden;
   padding: 0;
 }
 
@@ -64,4 +65,11 @@ a {
 button,
 textarea {
   font-family: 'Pretendard Variable', sans-serif;
+}
+
+#root {
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+  overflow-y: auto;
 }

--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -73,3 +73,13 @@ textarea {
   flex-direction: column;
   overflow-y: auto;
 }
+
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #c1c1c1;
+  border-radius: 12px;
+}


### PR DESCRIPTION
## 주요 변경 사항

- 전체 페이지 `#root`, `main` 화면높이에 꽉 차게 변경
- 스크롤바를  `#root` 요소로 옮기고 디자인 변경
- 공통 css 파일 import를 최상위 컴포넌트로 이동

## 관련 이슈

- 모달을 여는 버튼을 클릭 시, 스크롤바가 없어지면서 디자인이 밀리는 현상 발견
=> 기존에 모달 컴포넌트 내에 들어갔던 `document.body.style.overflow = 'hidden';`과 `document.body.style.overflow = 'unset';`을 제거하고 `#root`에 ` overflow-y: auto;` 속성 추가해서 문제 해결

## 리뷰어에게

- 아자아자