### PR TITLE
[Feat] 예약 현황 페이지 구현 및 공통 컴포넌트 수정

### DIFF
--- a/src/api/instance/axiosBaseQuery.ts
+++ b/src/api/instance/axiosBaseQuery.ts
@@ -1,0 +1,41 @@
+import type { BaseQueryFn } from '@reduxjs/toolkit/query';
+import type { AxiosError } from 'axios';
+import { AxiosArgs, AxiosQueryError } from '../types/axiosBase';
+import instance from './defaultInstance';
+
+// baseUrl을 받아서 axios 요청을 보내는 함수를 반환합니다.
+export function axiosBaseQuery(
+  { baseUrl }: { baseUrl: string } = { baseUrl: '' },
+): BaseQueryFn<string | AxiosArgs, unknown, AxiosQueryError> {
+  return async (args) => {
+    if (typeof args === 'string') {
+      args = { url: args };
+    }
+    const { url, body: data, headers = {}, ...config } = args ?? {};
+
+    // headers.Authorization = `Bearer ${localStorage.getItem('accessToken')}`;
+
+    // Axios 인스턴스를 사용하여 HTTP 요청을 수행합니다. 주어진 URL에 baseURL 추가하고, 데이터와 헤더를 포함하여 요청을 보냅니다.
+    try {
+      const response = await instance.request({
+        ...config,
+        url: baseUrl + url,
+        data,
+        headers,
+      });
+      return { data: response.data };
+    } catch (error) {
+      const axiosError = error as AxiosError;
+      const { message, response } = axiosError;
+      return {
+        error: {
+          cause: axiosError,
+          message,
+          response,
+        } as AxiosQueryError,
+      };
+    }
+  };
+}
+
+export default axiosBaseQuery;

--- a/src/api/reservationStatusApi.ts
+++ b/src/api/reservationStatusApi.ts
@@ -1,0 +1,52 @@
+import { createApi } from '@reduxjs/toolkit/query/react';
+import { BASE_URL } from './constants/url';
+import axiosBaseQuery from './instance/axiosBaseQuery';
+import { format } from 'date-fns';
+
+enum UpdateStatus {
+  declined = 0,
+  confirmed = 1,
+}
+
+export const reservationStatusApi = createApi({
+  // baseQuery: fetchBaseQuery({ baseUrl: BASE_URL }),
+  baseQuery: axiosBaseQuery({ baseUrl: BASE_URL }), // API의 기본 URL 설정
+  reducerPath: 'reservationStatusApi',
+  refetchOnMountOrArgChange: true, // 컴포넌트가 마운트되거나 매개변수가 변경될 때마다 새로고침
+  // 각각의 query/mutation 동작을 여기서 정의합니다.
+  endpoints: (builder) => ({
+    getActivityList: builder.query<MyActivities, void>({
+      query: () => 'my-activities', // 내 체험 리스트 조회 엔드포인트
+    }),
+    // builder.query<반환타입, 매개변수타입>, builder.query는 GET 요청을 보내는 함수
+    getReservationDashboard: builder.query<ReservationDashboard[], ReservationDashboardParams>({
+      // activityId는 호출에서 받은 값
+      query: ({ activityId, year, month }) =>
+        `my-activities/${activityId}/reservation-dashboard?year=${year}&month=${month}`, // 내 체험 월별 예약 현황 조회 엔드포인트
+    }),
+    getReservedSchedule: builder.query<ReservedSchedule[], ReservationScheduleParams>({
+      query: (schedule) =>
+        `my-activities/${schedule.activityId}/reserved-schedule?date=${format(schedule.date, 'yyyy-MM-dd')}`, // 내 체험 날짜별 예약 정보 조회 엔드포인트
+    }),
+    getTimeReservations: builder.query<TimeReservationList, TimeReservationParams>({
+      query: ({ activityId, scheduleId, status }) =>
+        `my-activities/${activityId}/reservations?scheduleId=${scheduleId}&status=${status}`, // 내 체험 예약 시간대별 예약 내역 조회 엔드포인트
+    }),
+    // mutation은 데이터 조작을 정의합니다. POST, PUT, DELETE, PATCH 등의 요청을 보낼 수 있습니다.
+    updateReservationStatus: builder.mutation<UpdateReservation, { activityId: number; reservationId: UpdateStatus }>({
+      query: ({ activityId, reservationId }) => ({
+        url: `my-activities/${activityId}/reservation-status/${reservationId}`, // 내 체험 예약 상태 업데이트 엔드포인트
+        method: 'PATCH',
+      }),
+    }),
+  }),
+});
+
+// 정의된 endpoints를 기반으로 자동 생성됩니다. getPost => useGetPostQuery
+export const {
+  useGetActivityListQuery,
+  useGetReservationDashboardQuery,
+  useGetReservedScheduleQuery,
+  useGetTimeReservationsQuery,
+  useUpdateReservationStatusMutation,
+} = reservationStatusApi;

--- a/src/api/types/axiosBase.ts
+++ b/src/api/types/axiosBase.ts
@@ -1,0 +1,15 @@
+import { SerializedError } from '@reduxjs/toolkit';
+import { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
+
+export interface AxiosArgs {
+  url: string;
+  method?: AxiosRequestConfig['method'];
+  body?: AxiosRequestConfig['data'];
+  params?: AxiosRequestConfig['params'];
+  headers?: AxiosRequestConfig['headers'];
+}
+
+export interface AxiosQueryError extends SerializedError {
+  cause: AxiosError;
+  response: AxiosResponse;
+}

--- a/src/api/types/reservationStatus.d.ts
+++ b/src/api/types/reservationStatus.d.ts
@@ -1,0 +1,98 @@
+interface Activity {
+  id: number;
+  userId: number;
+  title: string;
+  description: string;
+  category: string;
+  price: number;
+  address: string;
+  bannerImageUrl: string;
+  rating: number;
+  reviewCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface Reservation {
+  cursorId: number;
+  totalCount: number;
+}
+
+// 내 체험 리스트 조회
+interface MyActivities extends Reservation {
+  activities: Activity[];
+}
+
+type ReservationStatus = 'pending' | 'confirmed' | 'declined' | 'canceled' | 'completed';
+
+// 내 체험 월별 예약 현황 조회
+interface ReservationDashboard {
+  date: string;
+  reservations: {
+    completed: number;
+    confirmed: number;
+    pending: number;
+  };
+}
+
+interface ReservationDashboardParams {
+  activityId: number;
+  year: number;
+  month: string;
+}
+
+interface ReservationScheduleParams {
+  activityId: number;
+  date: Date;
+}
+
+interface Count {
+  declined: number;
+  confirmed: number;
+  pending: number;
+}
+
+// 내 체험 날짜별 예약 정보(신청, 승인, 거절)가 있는 스케줄 조회
+interface ReservedSchedule {
+  scheduleId: number;
+  startTime: string;
+  endTime: string;
+  count: Count;
+}
+
+interface ReservationInfo {
+  id: number;
+  userId: number;
+  teamId: string;
+  activityId: number;
+  scheduleId: number;
+  status: ReservationStatus;
+  reviewSubmitted: boolean;
+  totalPrice: number;
+  headCount: number;
+  date: string;
+  startTime: string;
+  endTime: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ReservationMoreInfo extends ReservationInfo {
+  nickname: string;
+}
+
+interface TimeReservationParams {
+  activityId: number;
+  scheduleId: number;
+  status: UpdateReservationStatus;
+}
+
+// 내 체험 예약 시간대별 예약 내역 조회
+interface TimeReservationList extends Reservation {
+  reservations: ReservationMoreInfo[];
+}
+
+// 내 체험 예약 상태(승인, 거절) 업데이트
+interface UpdateReservation {
+  status: UpdateReservationStatus;
+}

--- a/src/components/Calendar/components/CalendarCells.tsx
+++ b/src/components/Calendar/components/CalendarCells.tsx
@@ -17,13 +17,13 @@ export default function CalendarCells({ currentMonth, onChange, size = 'large', 
   return (
     <div className={`calendar-days-wrapper ${size}`}>
       {weekdays.map((weekday, index) => (
-        <div key={index} className="calendar-weekday">
+        <div key={`weekday-${index}`} className="calendar-weekday">
           {weekday}
         </div>
       ))}
       {dates.map(({ date }, index) => (
         <div
-          key={index + weekdays.length}
+          key={`date-${index}`}
           className={`calendar-date ${isSameDate(today, date) ? 'today' : ''}`}
           onClick={() => date && onChange?.(date)}
         >

--- a/src/components/Calendar/components/CalendarHeader.tsx
+++ b/src/components/Calendar/components/CalendarHeader.tsx
@@ -1,5 +1,6 @@
-import './calendarHeader.scss';
 import { format } from 'date-fns';
+import { useMemo } from 'react';
+import './calendarHeader.scss';
 
 export default function CalendarHeader({
   size = 'large',
@@ -7,12 +8,14 @@ export default function CalendarHeader({
   prevMonth,
   nextMonth,
 }: CalendarHeaderProps) {
+  const formattedMonth = useMemo(() => format(currentMonth, 'yyyy년 MM월'), [currentMonth]);
+
   return (
     <div className={`calendar-header-wrapper ${size}`}>
       <button onClick={prevMonth} type="button" className="calendar-header-button previous-button">
         <img src="/assets/icons/icon-left.svg" alt="이전 달" className="calendar-header-icon left-icon" />
       </button>
-      <div className="selected-month">{format(currentMonth, 'yyyy년 M월')}</div>
+      <div className="selected-month">{formattedMonth}</div>
       <button onClick={nextMonth} type="button" className="calendar-header-button next-button">
         <img src="/assets/icons/icon-right.svg" alt="다음 달" className="calendar-header-icon right-icon" />
       </button>

--- a/src/components/Calendar/components/CalendarReservationChip.tsx
+++ b/src/components/Calendar/components/CalendarReservationChip.tsx
@@ -1,0 +1,17 @@
+import './calendarReservationChip.scss';
+
+interface ChipProps {
+  color: string;
+  onClick?: () => void;
+  status?: string;
+}
+
+export default function CalendarReservationChip({ color, onClick, status }: ChipProps) {
+  return (
+    <div className="calendar-chips-wrapper">
+      <div className={`calendar-chip ${color}`} onClick={onClick}>
+        {status}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Calendar/components/ReservationInformation.tsx
+++ b/src/components/Calendar/components/ReservationInformation.tsx
@@ -1,0 +1,115 @@
+import { useGetReservedScheduleQuery, useGetTimeReservationsQuery } from '@/api/reservationStatusApi';
+import { translateMap } from '@/utils/calendarUtils';
+import { format } from 'date-fns';
+import { useState } from 'react';
+import Button from '../../Button';
+import './reservationInformation.scss';
+import { DropDown, DropDownValue, DropdownItem } from '@/components/Dropdown';
+
+interface HistoryProps {
+  reservation: ReservationMoreInfo;
+  selectedTab: UpdateReservationStatus;
+}
+
+export default function ReservationInformation({ chip, selectedDate, activityId }: ReservationInformationProps) {
+  const [selectedTab, setSelectedTab] = useState<UpdateReservationStatus>(
+    chip === 'completed' ? 'pending' : chip ?? 'pending',
+  ); // 예약 상태 선택
+  const { data: scheduleList } = useGetReservedScheduleQuery({ activityId, date: selectedDate }); // 내 체험 날짜별 예약 정보 조회 엔드포인트
+  const [scheduleId, setScheduleId] = useState<number>(scheduleList?.[0].scheduleId ?? 0); // 체험명 선택
+  const { data: reservationList } = useGetTimeReservationsQuery({
+    activityId,
+    scheduleId,
+    status: selectedTab,
+  }); // 내 체험 예약 시간대별 예약 내역 조회
+
+  const handleTabClick = (tab: UpdateReservationStatus) => {
+    setSelectedTab(tab);
+  };
+
+  const onClickTimeItem = (scheduleId: DropDownValue) => {
+    setScheduleId(scheduleId as number);
+  };
+
+  return (
+    <div className="reservation-information-wrapper">
+      <div className="reservation-information-title">예약 정보</div>
+      <div className="reservation-information-box">
+        <div className="reservation-information-tab">
+          <div
+            className={`reservation-information-tab-item ${selectedTab === 'pending' ? 'active' : ''}`}
+            onClick={() => handleTabClick('pending')}
+          >
+            신청
+          </div>
+          <div
+            className={`reservation-information-tab-item ${selectedTab === 'confirmed' ? 'active' : ''}`}
+            onClick={() => handleTabClick('confirmed')}
+          >
+            승인
+          </div>
+          <div
+            className={`reservation-information-tab-item ${selectedTab === 'declined' ? 'active' : ''}`}
+            onClick={() => handleTabClick('declined')}
+          >
+            거절
+          </div>
+        </div>
+        <div className="reservation-information-content-container">
+          <div className="reservation-information-content-title-box">
+            <div className="reservation-information-content-item">예약 날짜</div>
+            <div className="reservation-information-content-title-content">{format(selectedDate, 'yyyy.MM.dd.')}</div>
+          </div>
+          {/* 예약 시간 조회 */}
+          <div className="reservation-time-dropdown-box">
+            <DropDown
+              id="reservedTime"
+              title="시간을 선택하세요"
+              arrowUp={'∧'}
+              arrowDown={'∨'}
+              onClickItem={onClickTimeItem}
+            >
+              {scheduleList?.map((reservation) => (
+                <DropdownItem key={reservation.scheduleId} value={reservation.scheduleId}>
+                  {reservation.startTime + ' ~ ' + reservation.endTime}
+                </DropdownItem>
+              ))}
+            </DropDown>
+          </div>
+          <div className="reservation-information-content-item">예약 내역</div>
+          {reservationList?.reservations.map((reservation) => (
+            <History key={reservation.id} reservation={reservation} selectedTab={selectedTab} />
+          ))}
+          {reservationList?.reservations.length === 0 && '예약 내역이 없습니다.'}
+        </div>
+      </div>
+      <div className="reservation-information-content-reservation-status">
+        <div className="reservation-information-content-item">예약 현황</div>
+        <div className="reservation-information-content-item">{reservationList?.totalCount}</div>
+      </div>
+    </div>
+  );
+}
+
+function History({ reservation, selectedTab }: HistoryProps) {
+  return (
+    <div className="reservation-information-content-booking-history">
+      <div className="reservation-information-content-booking-history-content">
+        <div className="reservation-information-content-booking-history-item">닉네임</div>
+        <div className="reservation-information-content-booking-history-item-content">{reservation.nickname}</div>
+      </div>
+      <div className="reservation-information-content-booking-history-content">
+        <div className="reservation-information-content-booking-history-item">인원</div>
+        <div className="reservation-information-content-booking-history-item-content">{reservation.headCount}</div>
+      </div>
+      {selectedTab === 'pending' ? (
+        <div className="reservation-information-content-booking-history-buttons">
+          <Button type="submit" className="button-black button-booking-approve" children="승인하기" />
+          <Button type="submit" className="button-white button-booking-reject" children="거절하기" />
+        </div>
+      ) : (
+        <div className={'reservation-information-chip-wrapper approve'}>예약 {translateMap[selectedTab]}</div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Calendar/components/calendarCells.scss
+++ b/src/components/Calendar/components/calendarCells.scss
@@ -7,7 +7,6 @@
 .calendar-date {
   display: flex;
   color: var(--black20);
-  cursor: pointer;
 }
 
 .today {
@@ -30,6 +29,7 @@
   .calendar-date {
     display: flex;
     height: fit-content;
+    cursor: pointer;
 
     @media screen and (min-width: 768px) {
       height: fit-content;
@@ -98,14 +98,14 @@
     flex-direction: column;
     justify-content: flex-start;
     height: fit-content;
-    min-height: 70px;
+    min-height: 90px;
     padding: 3px;
     border-bottom: 1px solid var(--gray30);
 
     @media screen and (min-width: 768px) {
       padding: 10px;
       height: fit-content;
-      min-height: 110px;
+      min-height: 137px;
     }
 
     .calendar-date-box {
@@ -127,6 +127,7 @@
     align-items: center;
     border-bottom: 1px solid var(--gray30);
     font-weight: bold;
+    min-width: 45px;
     height: 25px;
     padding: 10px;
 
@@ -158,17 +159,17 @@
   }
 }
 
-.approve {
+.confirmed {
   @extend .calendar-icon-circle;
-  fill: var(--approve);
+  background-color: var(--approve);
 }
 
-.success {
+.completed {
   @extend .calendar-icon-circle;
-  fill: var(--success);
+  background-color: var(--success);
 }
 
-.reservation {
+.pending {
   @extend .calendar-icon-circle;
-  fill: var(--reservation);
+  background-color: var(--reservation);
 }

--- a/src/components/Calendar/components/calendarReservationChip.scss
+++ b/src/components/Calendar/components/calendarReservationChip.scss
@@ -1,0 +1,80 @@
+@mixin status($bg-color, $text-color) {
+  background: $bg-color;
+  color: $text-color;
+}
+
+.calendar-chips-wrapper {
+  font-size: 1rem;
+
+  @media screen and (min-width: 768px) {
+    justify-content: flex-start;
+    width: 100%;
+    height: fit-content;
+    border-radius: 5px;
+    padding: 3px 0;
+    font-size: 1.4rem;
+  }
+}
+
+.calendar-chip {
+  width: 100%;
+  display: inline-flex;
+  padding: 4px 6px;
+  justify-content: center;
+  align-items: center;
+  border-radius: 4px;
+  font-size: 1rem;
+  text-align: center;
+
+  @media (min-width: 768px) {
+    font-size: 1.3rem;
+  }
+}
+
+.approve-chip {
+  @include status(var(--approve), var(--white));
+  cursor: pointer;
+
+  &:hover {
+    background: var(--approve-hover);
+  }
+
+  @media (min-width: 769px) {
+    &:active,
+    &:hover {
+      animation: moveDownUp 0.2s linear;
+    }
+  }
+}
+
+.reservation-chip {
+  @include status(var(--reservation), var(--white));
+  cursor: pointer;
+
+  &:hover {
+    background: var(--reservation-hover);
+  }
+
+  @media (min-width: 769px) {
+    &:active,
+    &:hover {
+      animation: moveDownUp 0.2s linear;
+    }
+  }
+}
+
+.success-chip {
+  @include status(var(--success), var(--white));
+}
+
+@keyframes moveDownUp {
+  0% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(3px); /* 아래로 1px 이동 */
+  }
+  100% {
+    transform: translateY(0);
+  }
+}

--- a/src/components/Calendar/components/reservationInformation.scss
+++ b/src/components/Calendar/components/reservationInformation.scss
@@ -1,0 +1,237 @@
+@mixin status($bg-color, $text-color) {
+  background: $bg-color;
+  color: $text-color;
+}
+
+.reservation-information-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  min-width: 300px;
+  width: 100%;
+  height: 100%;
+  background-color: var(--white);
+  border-radius: 8px;
+  padding: 30px 20px;
+
+  @media screen and (min-width: 768px) {
+    min-width: 500px;
+    padding: 40px;
+  }
+}
+
+.reservation-information-box {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  background-color: var(--gray10);
+  border-bottom: 1px solid var(--gray30);
+  border-left: 1px solid var(--gray30);
+  border-right: 1px solid var(--gray30);
+  border-radius: 10px;
+}
+
+.reservation-information-title {
+  width: 100%;
+  color: var(--black20);
+  font-size: 2.3rem;
+  font-weight: bold;
+
+  @media screen and (min-width: 768px) {
+    font-size: 2.8rem;
+  }
+}
+
+.reservation-information-tab {
+  width: 100%;
+  display: flex;
+  border-bottom: 2px solid var(--gray30);
+  gap: 1px;
+}
+
+div.active {
+  background-color: var(--blue10);
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
+  border-top: var(--blue30);
+  border-bottom: 2px solid var(--blue20);
+  color: var(--black);
+}
+
+.reservation-information-tab-item {
+  width: 100%;
+  flex: 1;
+  padding: 10px;
+  background-color: var(--white);
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
+  box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.2);
+  cursor: pointer;
+  color: var(--gray60);
+  font-weight: bold;
+  text-align: center;
+
+  &:hover {
+    border-top-left-radius: 10px;
+    border-top-right-radius: 10px;
+    border-bottom: 2px solid var(--reservation-hover);
+    color: var(--black);
+  }
+}
+
+.reservation-information-content-container {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 0 20px 25px;
+}
+
+.reservation-information-content-title-box {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  .reservation-information-content-title-content {
+    color: var(--gray60);
+    font-size: 1.4rem;
+    font-weight: bold;
+
+    @media screen and (min-width: 768px) {
+      font-size: 1.6rem;
+    }
+  }
+}
+
+.reservation-information-content-item {
+  font-size: 1.6rem;
+  font-weight: bold;
+  @media screen and (min-width: 768px) {
+    font-size: 2rem;
+  }
+}
+
+.reservation-information-content-booking-history {
+  width: 100%;
+  height: 175px;
+  background-color: var(--white);
+  border: 1px solid var(--gray30);
+  border-radius: 10px;
+  padding: 20px 10px;
+
+  @media screen and (min-width: 768px) {
+    padding: 30px;
+    height: 200px;
+  }
+}
+
+.reservation-information-content-booking-history-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 0;
+}
+
+.reservation-information-content-booking-history-item {
+  color: var(--black20);
+  font-weight: bold;
+  font-size: 1.4rem;
+
+  @media screen and (min-width: 768px) {
+    font-size: 1.6rem;
+  }
+}
+
+.reservation-information-content-booking-history-item-content {
+  color: var(--gray60);
+  font-size: 1.4rem;
+  font-weight: bold;
+
+  @media screen and (min-width: 768px) {
+    font-size: 1.6rem;
+  }
+}
+
+.reservation-information-content-booking-history-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+
+  .button-booking-approve,
+  .button-booking-reject {
+    font-size: 1.3rem;
+    height: 40px;
+    margin-top: 10px;
+    border-radius: 50px;
+  }
+}
+
+.reservation-information-chip-wrapper {
+  display: flex;
+  flex-direction: column;
+  float: right;
+  align-items: flex-end;
+  width: fit-content;
+  margin-top: 10px;
+  padding: 10px 20px;
+  border-radius: 26px;
+  font-size: 1.3rem;
+  font-weight: bold;
+}
+
+.approve {
+  @include status(var(--reservation), var(--white));
+}
+
+.reject {
+  @include status(var(--red20), var(--red40));
+}
+
+.reservation-information-content-reservation-status {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.reservation-time-dropdown-box {
+  div.dropdown {
+    width: 100%;
+  }
+
+  div.dropdown-title {
+    height: 30px;
+    font-size: 1.4rem;
+
+    @media screen and (min-width: 768px) {
+      height: 30px;
+      padding: 0 5px;
+      font-size: 1.6rem;
+    }
+  }
+
+  #reservedTime {
+    width: 100%;
+
+    @media screen and (min-width: 768px) {
+      width: 100%;
+    }
+
+    li.dropdown-item {
+      padding: 10px 0;
+      font-size: 1.4rem;
+
+      @media screen and (min-width: 768px) {
+        font-size: 1.6rem;
+      }
+    }
+  }
+
+  .dropdown-arrow {
+    font-size: 2rem;
+    font-weight: bold;
+  }
+}

--- a/src/components/Calendar/types/calendarType.d.ts
+++ b/src/components/Calendar/types/calendarType.d.ts
@@ -20,9 +20,3 @@ interface CalendarProps {
 }
 
 type CalendarSize = 'small' | 'large';
-
-interface ReservationInformationChipProps {
-  status?: ReservationStatus;
-}
-
-type ReservationStatus = '승인' | '완료' | '예약';

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -8,17 +8,19 @@ interface DropDwonProps {
   arrowUp?: string;
   arrowDown?: string;
   children: React.ReactNode;
-  onClickItem?: (value: string, id: string) => void;
+  onClickItem?: (value: DropDownValue, id: string) => void;
 }
 
 interface DropdownItem {
-  value: string;
+  value: DropDownValue;
   children: React.ReactNode;
   itemStyle?: React.CSSProperties;
 }
 
+export type DropDownValue = string | number;
+
 interface DropdownContextProps {
-  handleClickItem?: (children: React.ReactNode, value: string) => void;
+  handleClickItem?: (children: React.ReactNode, value: DropDownValue) => void;
 }
 
 export const DropdownContext = createContext<DropdownContextProps>({});
@@ -77,13 +79,13 @@ export const DropDown = (props: DropDwonProps) => {
     return (
       <div className="dropdown-title">
         <div>{handleShowTitle()}</div>
-        {arrow ? <div>{arrow}</div> : null}
+        {arrow ? <div className="dropdown-arrow">{arrow}</div> : null}
       </div>
     );
   };
 
   // 드롭다운 클릭시 실행 함수
-  const handleClickItem = (children: React.ReactNode, value: string) => {
+  const handleClickItem = (children: React.ReactNode, value: DropDownValue) => {
     setSelect(children);
     onClickItem?.(value, id);
   };

--- a/src/pages/ErrorModal/index.tsx
+++ b/src/pages/ErrorModal/index.tsx
@@ -1,0 +1,17 @@
+import Button from '@/components/Button';
+import './style.scss';
+
+interface ErrorModalProps {
+  onClose: () => void;
+}
+
+export default function ErrorModal({ onClose }: ErrorModalProps) {
+  return (
+    <div className="error-wrapper">
+      <img src="/public/assets/logos/logo-notFound.svg" alt="로고" className="error-logo" />
+      <div className="error-title">ERROR</div>
+      <div className="error-message">빈 공간입니다. </div>
+      <Button children="뒤로 가기" type="button" onClick={onClose} className="button-black error-button" />
+    </div>
+  );
+}

--- a/src/pages/ErrorModal/style.scss
+++ b/src/pages/ErrorModal/style.scss
@@ -1,0 +1,49 @@
+.error-wrapper {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  width: 250px;
+  padding: 20px;
+  border-radius: 5px;
+  background-color: var(--white);
+
+  @media screen and (min-width: 768px) {
+    width: 500px;
+    gap: 10px;
+    padding: 30px;
+  }
+
+  .error-logo {
+    width: 100px;
+    height: 100px;
+    margin-top: 20px;
+
+    @media screen and (min-width: 768px) {
+      width: 150px;
+      height: 150px;
+    }
+  }
+
+  .error-title {
+    font-size: 1.6rem;
+    font-weight: bold;
+
+    @media screen and (min-width: 768px) {
+      font-size: 2rem;
+    }
+  }
+
+  .error-message {
+    font-size: 1.4rem;
+
+    @media screen and (min-width: 768px) {
+      font-size: 1.6rem;
+    }
+  }
+
+  .error-button {
+    margin-top: 30px;
+  }
+}

--- a/src/pages/Loading/index.tsx
+++ b/src/pages/Loading/index.tsx
@@ -1,10 +1,11 @@
 import './style.scss';
+import { LoadingProps } from './types/loadingType';
 
-export default function Loading() {
+export default function Loading({ type }: LoadingProps) {
   return (
-    <main className="loading-wrapper">
-      <img src="/assets/logos/logo-icon.svg" alt="로고" className="loading-logo" />
-      <img src="/assets/icons/icon-loading.svg" alt="로딩 중" className="loading-spinner" />
+    <main className={`loading-wrapper ${type}`}>
+      <img src="/public/assets/logos/logo-icon.svg" alt="로고" className="loading-logo" />
+      <img src="/public/assets/icons/icon-loading.svg" alt="로딩 중" className="loading-spinner" />
       <div className="loading-text-container">
         <div className="loading-text">로딩 중입니다.</div>
         <div className="loading-wait-text">잠시만 기다려주세요.</div>

--- a/src/pages/Loading/style.scss
+++ b/src/pages/Loading/style.scss
@@ -10,6 +10,10 @@
   height: 100vh;
   gap: 10px;
   background: rgba(0, 0, 0, 0.189);
+
+  &.loading-screen {
+    background-color: var(--white);
+  }
 }
 
 .loading-logo {

--- a/src/pages/ReservationStatus/index.tsx
+++ b/src/pages/ReservationStatus/index.tsx
@@ -1,3 +1,30 @@
+import useCalendar from '@/components/Calendar/hooks/useCalendar';
+import { isSameDate } from '@/utils/calendarUtils';
+import { format } from 'date-fns';
+import './style.scss';
+
 export default function ReservationStatus() {
-  return <main>예약현황 페이지 입니다.</main>;
+  const { Calendar, selectedDate } = useCalendar();
+
+  return (
+    <div className="reservation-status-wrapper">
+      <div className="reservation-status-title">예약 현황</div>
+      <Calendar
+        size="large"
+        tileContent={(date: Date) => {
+          const statusClass = 'confirmed';
+          return (
+            <>
+              <div className={`calendar-date-box ${isSameDate(selectedDate, date) ? 'selected-date' : ''}`}>
+                {format(date, 'd')}
+                <div className={`calendar-icon-circle ${statusClass}`} />
+              </div>
+              <div className="calendar-reservation-wrapper">
+              </div>
+            </>
+          );
+        }}
+      />
+    </div>
+  );
 }

--- a/src/pages/ReservationStatus/index.tsx
+++ b/src/pages/ReservationStatus/index.tsx
@@ -1,18 +1,94 @@
+import { useGetActivityListQuery, useGetReservationDashboardQuery } from '@/api/reservationStatusApi';
+import CalendarReservationChip from '@/components/Calendar/components/CalendarReservationChip';
+import ReservationInformation from '@/components/Calendar/components/ReservationInformation';
 import useCalendar from '@/components/Calendar/hooks/useCalendar';
-import { isSameDate } from '@/utils/calendarUtils';
-import { format } from 'date-fns';
+import { DropDown, DropDownValue, DropdownItem } from '@/components/Dropdown';
+import { useModal } from '@/hooks/useModal/useModal';
+import { isSameDate, statusChips, statusMap, translateMap } from '@/utils/calendarUtils';
+import { format, getYear } from 'date-fns';
+import { useEffect, useState } from 'react';
+import ErrorModal from '../ErrorModal';
+import Loading from '../Loading';
 import './style.scss';
 
 export default function ReservationStatus() {
-  const { Calendar, selectedDate } = useCalendar();
+  const { Calendar, selectedDate, setSelectedDate } = useCalendar();
+  const { data: myActivities, isLoading, isFetching, isError } = useGetActivityListQuery(); // 내 체험 리스트 조회
+  const [activityId, setActivityId] = useState<number>(myActivities?.activities[0].id ?? 0); // 체험명 선택
+  const [selectedChip, setSelectedChip] = useState<ReservationChip>('pending'); // 예약 상태 선택
+  const { data: myDashboard } = useGetReservationDashboardQuery({
+    activityId,
+    year: getYear(selectedDate),
+    month: format(selectedDate, 'MM'),
+  });
+  const { Modal, openModal, closeModal } = useModal();
+
+  const handleTagClick = (date: Date, chip: ReservationChip) => {
+    setSelectedDate(date);
+    setSelectedChip(chip);
+    if (chip === 'pending' || chip === 'confirmed') {
+      openModal('reservation');
+    }
+  };
+
+  const onClickItem = (value: DropDownValue) => {
+    myActivities?.activities.forEach((activity) => {
+      if (activity.title === value) {
+        setActivityId(activity.id);
+      }
+    }, []);
+  };
+
+  useEffect(() => {
+    if (isError) openModal('error');
+  }, [isError]);
+
+  if (isLoading || isFetching) return <Loading type="loading-screen" />;
+  if (isError) {
+    return (
+      <Modal name="error">
+        <ErrorModal onClose={closeModal} />
+      </Modal>
+    );
+  }
 
   return (
     <div className="reservation-status-wrapper">
       <div className="reservation-status-title">예약 현황</div>
+      <div className="reservation-status-dropdown-box">
+        <div className="reservation-status-dropdown-title">체험명</div>
+        {/* 내 체험 리스트 조회 */}
+        <DropDown
+          id="activityNames"
+          title={'체험을 선택해주세요.'}
+          arrowUp={'∧'}
+          arrowDown={'∨'}
+          onClickItem={onClickItem}
+        >
+          {myActivities?.activities.map((activity) => (
+            <DropdownItem key={activity.id} value={activity.title}>
+              {activity.title}
+            </DropdownItem>
+          ))}
+        </DropDown>
+      </div>
+      {/* 내 체험 월별 예약 현황 조회 */}
       <Calendar
         size="large"
         tileContent={(date: Date) => {
-          const statusClass = 'confirmed';
+          const reservation = myDashboard?.find((r) => r.date === format(date, 'yyyy-MM-dd'));
+          const reservations = reservation?.reservations ?? { pending: 0, confirmed: 0, completed: 0 };
+
+          let statusClass = '';
+
+          if (reservations.pending > 0) {
+            statusClass = 'pending';
+          } else if (reservations.confirmed > 0) {
+            statusClass = 'confirmed';
+          } else if (reservations.completed > 0) {
+            statusClass = 'completed';
+          }
+
           return (
             <>
               <div className={`calendar-date-box ${isSameDate(selectedDate, date) ? 'selected-date' : ''}`}>
@@ -20,11 +96,28 @@ export default function ReservationStatus() {
                 <div className={`calendar-icon-circle ${statusClass}`} />
               </div>
               <div className="calendar-reservation-wrapper">
+                {statusChips.map(
+                  (chip, index) =>
+                    (reservations[chip] ?? 0) !== 0 && (
+                      <CalendarReservationChip
+                        key={chip + '-' + index}
+                        status={`${translateMap[chip]} ${reservations[chip]}`}
+                        color={statusMap[chip] + '-chip'}
+                        onClick={() => handleTagClick(date, chip)}
+                      />
+                    ),
+                )}
               </div>
             </>
           );
         }}
       />
+      {/* 내 체험 날짜별 예약 정보(신청, 승인, 거절)가 있는 스케줄 조회 */}
+      {/* 내 체험 예약 시간대별 예약 내역 조회 */}
+      {/* 내 체험 예약 상태(승인, 거절) 업데이트 */}
+      <Modal name="reservation">
+        <ReservationInformation activityId={activityId} chip={selectedChip} selectedDate={selectedDate} />
+      </Modal>
     </div>
   );
 }

--- a/src/pages/ReservationStatus/style.scss
+++ b/src/pages/ReservationStatus/style.scss
@@ -1,0 +1,80 @@
+.reservation-status-wrapper {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  width: 100%;
+  gap: 20px;
+
+  .reservation-status-title {
+    padding: 0 10px;
+
+    @media screen and (min-width: 768px) {
+      padding: 0 30px;
+    }
+  }
+
+  .reservation-status-dropdown-title {
+    position: absolute;
+    top: 60px;
+    left: 20px;
+    z-index: 1;
+    padding: 0 5px;
+    background-color: var(--white);
+    color: var(--black20);
+    font-size: 1.4rem;
+    font-weight: bold;
+
+    @media screen and (min-width: 768px) {
+      top: 80px;
+      left: 50px;
+      font-size: 1.6rem;
+    }
+  }
+}
+
+.reservation-status-title {
+  font-size: 3.2rem;
+  font-weight: 700;
+  color: var(--black20);
+}
+
+.reservation-status-dropdown-box {
+  padding: 10px;
+
+  @media screen and (min-width: 768px) {
+    padding: 30px;
+  }
+
+  div.dropdown-title {
+    height: 30px;
+    font-size: 1.4rem;
+
+    @media screen and (min-width: 768px) {
+      height: 40px;
+      padding: 0 5px;
+      font-size: 1.6rem;
+    }
+  }
+
+  #activityNames {
+    width: 100%;
+
+    @media screen and (min-width: 768px) {
+      width: 100%;
+    }
+
+    li.dropdown-item {
+      padding: 10px 0;
+      font-size: 1.4rem;
+
+      @media screen and (min-width: 768px) {
+        font-size: 1.6rem;
+      }
+    }
+  }
+
+  .dropdown-arrow {
+    font-size: 2rem;
+    font-weight: bold;
+  }
+}

--- a/src/pages/ReservationStatus/style.scss
+++ b/src/pages/ReservationStatus/style.scss
@@ -1,9 +1,13 @@
-.reservation-status-wrapper {
+div.reservation-status-wrapper {
   display: flex;
   flex-direction: column;
   position: relative;
   width: 100%;
   gap: 20px;
+
+  @media screen and (min-width: 768px) {
+    min-width: 100%;
+  }
 
   .reservation-status-title {
     padding: 0 10px;

--- a/src/pages/ReservationStatus/types/reservationTypes.d.ts
+++ b/src/pages/ReservationStatus/types/reservationTypes.d.ts
@@ -7,7 +7,7 @@ interface ReservationInformationProps {
   activityId: number;
 }
 
-type UpdateReservationStatus = 'pending' | 'confirmed' | 'rejected';
+type UpdateReservationStatus = 'pending' | 'confirmed' | 'declined';
 
 interface UpdateReservationStatusProps {
   status?: UpdateReservation;

--- a/src/pages/ReservationStatus/types/reservationTypes.d.ts
+++ b/src/pages/ReservationStatus/types/reservationTypes.d.ts
@@ -1,0 +1,14 @@
+type ReservationChip = 'pending' | 'confirmed' | 'completed';
+
+interface ReservationInformationProps {
+  selectedDate: Date;
+  status?: ReservationStatus;
+  chip?: ReservationChip;
+  activityId: number;
+}
+
+type UpdateReservationStatus = 'pending' | 'confirmed' | 'rejected';
+
+interface UpdateReservationStatusProps {
+  status?: UpdateReservation;
+}

--- a/src/redux/store/index.ts
+++ b/src/redux/store/index.ts
@@ -1,11 +1,17 @@
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { persistStore, persistReducer } from 'redux-persist';
 import storage from 'redux-persist/lib/storage';
 import myInfo from '../myInfoSlice';
 
+import reservationStatus from '../reservationStatusSlice';
+import { reservationStatusApi } from '@/api/reservationStatusApi';
+
 const rootReducer = combineReducers({
   myInfo,
+  reservationStatus,
+  [reservationStatusApi.reducerPath]: reservationStatusApi.reducer,
+  // reservationStatusApi: reservationStatusApi, // 이렇게 하면 틀릴 수도 있음
 });
 
 const persistConfig = {
@@ -18,13 +24,18 @@ const persistedReducer = persistReducer(persistConfig, rootReducer);
 export const store = configureStore({
   reducer: persistedReducer,
   middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware().concat(
+    getDefaultMiddleware({
+      serializableCheck: false,
+    }).concat(
       // prettier-ignore
+      reservationStatusApi.middleware,
     ),
 });
 
 const persistedStore = persistStore(store);
 
 export default persistedStore;
+export const useAppDispatch: () => AppDispatch = useDispatch;
 export const useAppSelector = useSelector.withTypes<RootState>();
+export type AppDispatch = typeof store.dispatch;
 export type RootState = ReturnType<typeof store.getState>;

--- a/src/redux/store/index.ts
+++ b/src/redux/store/index.ts
@@ -4,12 +4,10 @@ import { persistStore, persistReducer } from 'redux-persist';
 import storage from 'redux-persist/lib/storage';
 import myInfo from '../myInfoSlice';
 
-import reservationStatus from '../reservationStatusSlice';
 import { reservationStatusApi } from '@/api/reservationStatusApi';
 
 const rootReducer = combineReducers({
   myInfo,
-  reservationStatus,
   [reservationStatusApi.reducerPath]: reservationStatusApi.reducer,
   // reservationStatusApi: reservationStatusApi, // 이렇게 하면 틀릴 수도 있음
 });

--- a/src/utils/calendarUtils.ts
+++ b/src/utils/calendarUtils.ts
@@ -2,7 +2,6 @@ import { addDays, getDaysInMonth, startOfMonth } from 'date-fns';
 
 export interface DateWithStatus {
   date?: Date;
-  status?: ReservationStatus;
 }
 
 export default function generateDates(currentMonth: Date): DateWithStatus[] {
@@ -12,10 +11,10 @@ export default function generateDates(currentMonth: Date): DateWithStatus[] {
 
   const datesArray: DateWithStatus[] = [];
   for (let i = 0; i < startingWeekday; i++) {
-    datesArray.push({ date: undefined, status: undefined });
+    datesArray.push({ date: undefined });
   }
   for (let i = 1; i <= daysInMonth; i++) {
-    datesArray.push({ date: addDays(firstDayOfMonth, i - 1), status: status[(i - 1) % status.length] });
+    datesArray.push({ date: addDays(firstDayOfMonth, i - 1) });
   }
   return datesArray;
 }
@@ -28,10 +27,17 @@ export const isSameDate = (selectedDate: Date, date?: Date) => {
   );
 };
 
-export const status: ReservationStatus[] = ['승인', '완료', '예약'];
+export const statusChips: ReservationChip[] = ['pending', 'confirmed', 'completed'];
 
 export const statusMap = {
-  승인: 'approve',
-  완료: 'success',
-  예약: 'reservation',
+  pending: 'reservation',
+  confirmed: 'approve',
+  completed: 'success',
+};
+
+export const translateMap = {
+  pending: '예약',
+  confirmed: '승인',
+  completed: '완료',
+  declined: '거절',
 };


### PR DESCRIPTION
## 이슈 번호

#13 
#25 

## 주요 변경 사항

- 달력 컴포넌트 디자인 및 타입 정의
- 예약 현황 페이지 구현
- 드롭다운 `value` 타입을 `string`에서 `string | number` 로 변경하기 위한 `DropDownValue` 타입 추가


## 관련 스크린샷

![2024-05-03 03;04;14](https://github.com/Sprint3-6/yeogiya/assets/113954463/6a0272b0-39e4-4308-824d-b6cc074820da)


## 리뷰어에게

- 예약 승인하기/거절하기 기능은 아직 못 넣었고
- 아직 예약 상태 클릭 후 모달 화면이 미완성입니다. (시간 드롭다운 선택 후 예약 내역 보이게 수정할 예정)
- 예약 현황 페이지 딱 뜨자마자 예약 현황을 모두 보여주는 기능을 아직 넣지 못했습니다!
- 파일이 너무 많네요^^............죄송합니다
- 졸려요 굿바아아암 모두 행복하게 주무세요