### PR TITLE
[Fix] 예약 현황 페이지에서 드롭다운 선택 시 예약 현황 보이도록 수정 등

### DIFF
--- a/src/api/reservationStatusApi.ts
+++ b/src/api/reservationStatusApi.ts
@@ -3,7 +3,7 @@ import { BASE_URL } from './constants/url';
 import axiosBaseQuery from './instance/axiosBaseQuery';
 import { format } from 'date-fns';
 
-enum UpdateStatus {
+export const enum UpdateStatus {
   declined = 0,
   confirmed = 1,
 }
@@ -33,9 +33,10 @@ export const reservationStatusApi = createApi({
         `my-activities/${activityId}/reservations?scheduleId=${scheduleId}&status=${status}`, // 내 체험 예약 시간대별 예약 내역 조회 엔드포인트
     }),
     // mutation은 데이터 조작을 정의합니다. POST, PUT, DELETE, PATCH 등의 요청을 보낼 수 있습니다.
-    updateReservationStatus: builder.mutation<UpdateReservation, { activityId: number; reservationId: UpdateStatus }>({
-      query: ({ activityId, reservationId }) => ({
-        url: `my-activities/${activityId}/reservation-status/${reservationId}`, // 내 체험 예약 상태 업데이트 엔드포인트
+    updateReservationStatus: builder.mutation<UpdateReservation, UpdateReservationParams>({
+      query: ({ activityId, reservationId, status }) => ({
+        url: `my-activities/${activityId}/reservations/${reservationId}`, // 내 체험 예약 상태 업데이트 엔드포인트
+        body: { status },
         method: 'PATCH',
       }),
     }),
@@ -45,8 +46,8 @@ export const reservationStatusApi = createApi({
 // 정의된 endpoints를 기반으로 자동 생성됩니다. getPost => useGetPostQuery
 export const {
   useGetActivityListQuery,
-  useGetReservationDashboardQuery,
   useGetReservedScheduleQuery,
-  useGetTimeReservationsQuery,
+  useLazyGetTimeReservationsQuery,
+  useLazyGetReservationDashboardQuery,
   useUpdateReservationStatusMutation,
 } = reservationStatusApi;

--- a/src/api/types/reservationStatus.d.ts
+++ b/src/api/types/reservationStatus.d.ts
@@ -96,3 +96,9 @@ interface TimeReservationList extends Reservation {
 interface UpdateReservation {
   status: UpdateReservationStatus;
 }
+
+interface UpdateReservationParams {
+  activityId: number;
+  reservationId: number;
+  status: 'confirmed' | 'declined';
+}

--- a/src/components/Button/types/buttonType.ts
+++ b/src/components/Button/types/buttonType.ts
@@ -3,5 +3,6 @@ import { ButtonHTMLAttributes, PropsWithChildren } from 'react';
 export interface Props extends PropsWithChildren, ButtonHTMLAttributes<HTMLButtonElement> {
   className?: string;
   onClick?: () => void;
+  onClose?: () => void;
   type?: 'button' | 'submit' | 'reset';
 }

--- a/src/components/Calendar/components/calendarCells.scss
+++ b/src/components/Calendar/components/calendarCells.scss
@@ -163,19 +163,19 @@
       height: 8px;
     }
   }
-}
 
-.confirmed {
-  @extend .calendar-icon-circle;
-  background-color: var(--approve);
-}
+  .confirmed {
+    @extend .calendar-icon-circle;
+    background-color: var(--approve);
+  }
 
-.completed {
-  @extend .calendar-icon-circle;
-  background-color: var(--success);
-}
+  .completed {
+    @extend .calendar-icon-circle;
+    background-color: var(--success);
+  }
 
-.pending {
-  @extend .calendar-icon-circle;
-  background-color: var(--reservation);
+  .pending {
+    @extend .calendar-icon-circle;
+    background-color: var(--reservation);
+  }
 }

--- a/src/components/Calendar/components/reservationInformation.scss
+++ b/src/components/Calendar/components/reservationInformation.scss
@@ -1,8 +1,3 @@
-@mixin status($bg-color, $text-color) {
-  background: $bg-color;
-  color: $text-color;
-}
-
 .reservation-information-wrapper {
   display: flex;
   flex-direction: column;
@@ -125,6 +120,16 @@ div.active {
     padding: 30px;
     height: 200px;
   }
+
+  .confirmed {
+    background-color: var(--reservation);
+    color: var(--white);
+  }
+
+  .declined {
+    background-color: var(--red20);
+    color: var(--red40);
+  }
 }
 
 .reservation-information-content-booking-history-content {
@@ -180,14 +185,6 @@ div.active {
   border-radius: 26px;
   font-size: 1.3rem;
   font-weight: bold;
-}
-
-.approve {
-  @include status(var(--reservation), var(--white));
-}
-
-.reject {
-  @include status(var(--red20), var(--red40));
 }
 
 .reservation-information-content-reservation-status {

--- a/src/hooks/useModal/useModal.scss
+++ b/src/hooks/useModal/useModal.scss
@@ -18,7 +18,7 @@
   bottom: 0;
   left: 0;
   background-color: rgba(0, 0, 0, 0.7);
-  z-index: 9999;
+  z-index: 1000;
   justify-content: center;
   align-items: center;
   display: flex;

--- a/src/pages/ErrorModal/index.tsx
+++ b/src/pages/ErrorModal/index.tsx
@@ -8,7 +8,7 @@ interface ErrorModalProps {
 export default function ErrorModal({ onClose }: ErrorModalProps) {
   return (
     <div className="error-wrapper">
-      <img src="/public/assets/logos/logo-notFound.svg" alt="로고" className="error-logo" />
+      <img src="/assets/logos/logo-notFound.svg" alt="로고" className="error-logo" />
       <div className="error-title">ERROR</div>
       <div className="error-message">빈 공간입니다. </div>
       <Button children="뒤로 가기" type="button" onClick={onClose} className="button-black error-button" />

--- a/src/pages/Loading/index.tsx
+++ b/src/pages/Loading/index.tsx
@@ -4,8 +4,8 @@ import { LoadingProps } from './types/loadingType';
 export default function Loading({ type }: LoadingProps) {
   return (
     <main className={`loading-wrapper ${type}`}>
-      <img src="/public/assets/logos/logo-icon.svg" alt="로고" className="loading-logo" />
-      <img src="/public/assets/icons/icon-loading.svg" alt="로딩 중" className="loading-spinner" />
+      <img src="/assets/logos/logo-icon.svg" alt="로고" className="loading-logo" />
+      <img src="/assets/icons/icon-loading.svg" alt="로딩 중" className="loading-spinner" />
       <div className="loading-text-container">
         <div className="loading-text">로딩 중입니다.</div>
         <div className="loading-wait-text">잠시만 기다려주세요.</div>

--- a/src/pages/Loading/types/loadingType.ts
+++ b/src/pages/Loading/types/loadingType.ts
@@ -1,0 +1,3 @@
+export interface LoadingProps {
+  type: string;
+}


### PR DESCRIPTION
## 이슈 번호

#25 

## 주요 변경 사항

- 로딩 페이지 타입 오류 수정
- 로딩, 에러 페이지 img 경로 내 public 제거
- 토스트가 모달보다 위에 뜨도록 모달 z-index 수정
- 예약 현황 칩 클릭 시 모달 내 예약 현황 개수 탭에 맞게 숫자 변경되도록 수정
- 예약 현황 모달 내 예약 승인/예약 거절 api 연결하여 기능 구현되도록 수정

## 관련 스크린샷

![image](https://github.com/Sprint3-6/yeogiya/assets/113954463/aa8cf614-824d-48c1-94c2-aba160e8505e)

## 리뷰어에게

- 벼락치기로 바꾼 게 쫌 되는데 아직 미완성이라니!
- 이제 무한스크롤 추가해야 하고, 예약 현황 모달에서 시간 드롭다운을 클릭해야 예약 내역이 뜨도록 변경해야 합니다(드롭다운 내 기능 추가 필요할 예정)
- 예약 현황 모달 내 예약 승인/예약 거절 클릭했을 때 모달 닫히게 하려고 onClose 넣긴 했는데 그 기능이 먹히질 않아서 수정할 예정입니다
- 모듀 행복한 맛저되세요오오 