### PR TITLE
[Design] form 안 input css 통일 및 기타 작업

### DIFF
--- a/src/api/activitiesApi.ts
+++ b/src/api/activitiesApi.ts
@@ -1,4 +1,3 @@
-import toast from '@/utils/toast';
 import instance from './instance/defaultInstance';
 import { CreateActivityBody } from './types/myActivities';
 
@@ -19,11 +18,5 @@ export const uploadImage = async (imageFile: File) => {
 };
 
 export const postData = async (body: CreateActivityBody) => {
-  try {
-    const response = await instance.post('activities', body);
-    toast.success('등록이 완료되었습니다!');
-    return response;
-  } catch (error) {
-    console.error('내 체험 등록 오류:', error);
-  }
+  await instance.post('activities', body);
 };

--- a/src/api/myActivitiesApi.ts
+++ b/src/api/myActivitiesApi.ts
@@ -17,9 +17,5 @@ export const getMyActivities = async (size: number, cursorId: number | null) => 
 };
 
 export const editMyActivities = async (id: string, body: EditActivityBody) => {
-  try {
-    await instance.patch(`my-activities/${id}`, body);
-  } catch (error) {
-    console.error('변경 오류:', error);
-  }
+  await instance.patch(`my-activities/${id}`, body);
 };

--- a/src/hooks/useAddPlaceForm/index.ts
+++ b/src/hooks/useAddPlaceForm/index.ts
@@ -6,6 +6,7 @@ import { postData } from '@/api/activitiesApi';
 import removeCommas from '@/utils/removeCommas';
 import { Schedule } from '@/api/types/myActivities';
 import { PlaceInputValue } from '@/pages/AddSpace/types';
+import { ErrorType } from '@/api/types/axiosErrorType';
 
 export default function useAddPlaceForm() {
   const [bannerImage, setBannerImage] = useState<string[]>([]);
@@ -22,7 +23,7 @@ export default function useAddPlaceForm() {
     getValues,
   } = useForm<PlaceInputValue>({ mode: 'onSubmit' });
 
-  const onSubmit: SubmitHandler<PlaceInputValue> = (data) => {
+  const onSubmit: SubmitHandler<PlaceInputValue> = async (data) => {
     setIsSubmitted(true);
     if (!category) {
       toast.warning('카테고리를 선택해주세요!');
@@ -41,10 +42,15 @@ export default function useAddPlaceForm() {
         bannerImageUrl: bannerImage[0],
         subImageUrls: subimages,
       };
-      postData(body).then(() => {
+      try {
+        await postData(body);
+        toast.success('등록이 완료되었습니다');
         // 업로드 성공 시 페이지 이동
         navigate('/mypage/admin');
-      });
+      } catch (err) {
+        const error = err as ErrorType;
+        toast.error(error.response.data.message);
+      }
     }
   };
 

--- a/src/hooks/useEditSpaceForm/index.ts
+++ b/src/hooks/useEditSpaceForm/index.ts
@@ -9,6 +9,7 @@ import removeCommas from '@/utils/removeCommas';
 import getSpaceDetail, { SchedulePlusId, SpaceDetail } from '@/api/getSpaceDetail';
 import { editMyActivities } from '@/api/myActivitiesApi';
 import { PlaceInputValue } from '@/pages/AddSpace/types';
+import { ErrorType } from '@/api/types/axiosErrorType';
 
 interface UrlSubData {
   id: number;
@@ -61,7 +62,7 @@ export default function useEditSpaceForm() {
     getValues,
   } = useForm<PlaceInputValue>({ mode: 'onSubmit' });
 
-  const onSubmit: SubmitHandler<PlaceInputValue> = (data) => {
+  const onSubmit: SubmitHandler<PlaceInputValue> = async (data) => {
     setIsSubmitted(true);
     if (!category) {
       toast.warning('카테고리를 선택해주세요!');
@@ -82,10 +83,14 @@ export default function useEditSpaceForm() {
         subImageIdsToRemove: findMissingImgIds(preSubimages.current, subimages),
         scheduleIdsToRemove: findMissingScheduleIds(preSchedules.current, schedules),
       };
-      editMyActivities(id!, body).then(() => {
+      try {
+        await editMyActivities(id!, body);
         toast.success('수정이 되었습니다!');
         navigate('/mypage/admin');
-      });
+      } catch (err) {
+        const error = err as ErrorType;
+        toast.error(error.response.data.message);
+      }
     }
     return;
   };

--- a/src/pages/AddSpace/comnponents/AddPlaceForm/style.scss
+++ b/src/pages/AddSpace/comnponents/AddPlaceForm/style.scss
@@ -49,7 +49,7 @@
 
 .form-input {
   width: 100%;
-  border: 1px solid #a1a1a1;
+  border: 1px solid var(--gray50);
   padding: 8px 16px;
   height: 56px;
   border-radius: 4px;
@@ -63,7 +63,7 @@ input::-webkit-inner-spin-button {
 
 .form-textarea {
   resize: none;
-  border: 1px solid #a1a1a1;
+  border: 1px solid var(--gray50);
   padding: 16px;
   height: 346px;
   border-radius: 4px;

--- a/src/pages/AddSpace/comnponents/AddPlaceForm/style.scss
+++ b/src/pages/AddSpace/comnponents/AddPlaceForm/style.scss
@@ -53,6 +53,12 @@
   padding: 8px 16px;
   height: 56px;
   border-radius: 4px;
+  &:focus {
+    outline: none;
+  }
+  &:active {
+    border: 2px solid black;
+  }
 }
 
 input::-webkit-outer-spin-button,
@@ -67,6 +73,12 @@ input::-webkit-inner-spin-button {
   padding: 16px;
   height: 346px;
   border-radius: 4px;
+  &:focus {
+    outline: none;
+  }
+  &:active {
+    border: 2px solid black;
+  }
 }
 
 .post-search-box {

--- a/src/pages/AddSpace/comnponents/CategoryDropdown/index.tsx
+++ b/src/pages/AddSpace/comnponents/CategoryDropdown/index.tsx
@@ -1,4 +1,4 @@
-import { DropDown, DropdownItem } from '@/components/Dropdown';
+import { DropDown, DropDownValue, DropdownItem } from '@/components/Dropdown';
 import categoryFilter from '@/utils/categoryFilter';
 import { InputHTMLAttributes } from 'react';
 import './styles.scss';
@@ -9,8 +9,10 @@ interface CategoryDropdownProps extends InputHTMLAttributes<HTMLInputElement> {
 }
 
 export default function CategoryDropdown({ setCategory, initValue }: CategoryDropdownProps) {
-  const handleDropdown = (value: string) => {
-    setCategory(value);
+  const handleDropdown = (value: DropDownValue) => {
+    if (typeof value === 'string') {
+      setCategory(value);
+    }
   };
 
   const changedInitValue = categoryFilter(initValue);
@@ -24,12 +26,12 @@ export default function CategoryDropdown({ setCategory, initValue }: CategoryDro
         arrowUp="∧"
         arrowDown="∨"
       >
-        <DropdownItem value="문화 · 예술">파티룸</DropdownItem>
-        <DropdownItem value="식음료">이벤트홀</DropdownItem>
-        <DropdownItem value="스포츠">스튜디오</DropdownItem>
-        <DropdownItem value="투어">공연장</DropdownItem>
-        <DropdownItem value="관광">회의장</DropdownItem>
-        <DropdownItem value="웰빙">연습실</DropdownItem>
+        <DropdownItem value="문화 · 예술">🎉 파티룸</DropdownItem>
+        <DropdownItem value="식음료">🎈 이벤트홀</DropdownItem>
+        <DropdownItem value="스포츠">🎥 스튜디오</DropdownItem>
+        <DropdownItem value="투어">🕋 공연장</DropdownItem>
+        <DropdownItem value="관광">🤵 회의장</DropdownItem>
+        <DropdownItem value="웰빙">🎤 연습실</DropdownItem>
       </DropDown>
     </div>
   );

--- a/src/pages/AddSpace/comnponents/CategoryDropdown/styles.scss
+++ b/src/pages/AddSpace/comnponents/CategoryDropdown/styles.scss
@@ -1,5 +1,9 @@
 .input-category .dropdown {
+  &:focus {
+    border-color: black;
+  }
   .dropdown-select {
+    box-shadow: 0 0 1px var(--red40);
     height: 56px;
     justify-content: center;
   }
@@ -8,5 +12,7 @@
   }
   .dropdown-item {
     padding: 12px 0;
+    padding-left: 60px;
+    align-items: flex-start;
   }
 }

--- a/src/pages/AddSpace/comnponents/CategoryDropdown/styles.scss
+++ b/src/pages/AddSpace/comnponents/CategoryDropdown/styles.scss
@@ -3,9 +3,13 @@
     border-color: black;
   }
   .dropdown-select {
-    box-shadow: 0 0 1px var(--red40);
+    border: 1px solid var(--gray50);
+    box-shadow: 0 0 0 0;
     height: 56px;
     justify-content: center;
+    &:active {
+      border: 2px solid black;
+    }
   }
   .dropdown-list {
     max-height: 300px;

--- a/src/pages/AddSpace/comnponents/Schdules/DateInput/index.tsx
+++ b/src/pages/AddSpace/comnponents/Schdules/DateInput/index.tsx
@@ -2,7 +2,7 @@ import { Schedule } from '@/api/types/myActivities';
 import useCalendar from '@/components/Calendar/hooks/useCalendar';
 import { isSameDate } from '@/utils/calendarUtils';
 import { format } from 'date-fns';
-import { InputHTMLAttributes, useState } from 'react';
+import { InputHTMLAttributes, useEffect, useRef, useState } from 'react';
 import './style.scss';
 
 interface DateInput extends InputHTMLAttributes<HTMLInputElement> {
@@ -13,8 +13,26 @@ interface DateInput extends InputHTMLAttributes<HTMLInputElement> {
 export default function DateInput({ preViewValue, setPreViewValue }: DateInput) {
   const { Calendar, selectedDate, setSelectedDate } = useCalendar();
   const [isOpenCalendar, setIsOpenCalendar] = useState(false);
+  const calendarRef = useRef<HTMLDivElement>(null);
+  const labelRef = useRef<HTMLLabelElement>(null);
   const openCalendar = () => {
     setIsOpenCalendar((pre) => !pre);
+  };
+  useEffect(() => {
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  const handleClickOutside = (event: MouseEvent) => {
+    if (
+      calendarRef.current &&
+      !calendarRef.current.contains(event.target as Node) &&
+      !labelRef.current?.contains(event.target as Node)
+    ) {
+      setIsOpenCalendar(false);
+    }
   };
   const handleDateChange = (date: Date) => {
     const formattedDate = format(date, 'yyyy-MM-dd');
@@ -30,7 +48,7 @@ export default function DateInput({ preViewValue, setPreViewValue }: DateInput) 
   return (
     <div className="calendar-box">
       <div className="calendar-input-title">날짜</div>
-      <label className="calendar-label" htmlFor="date-input">
+      <label ref={labelRef} className="calendar-label" htmlFor="date-input">
         <input
           className="calendar-input"
           value={preViewValue.date}
@@ -42,7 +60,7 @@ export default function DateInput({ preViewValue, setPreViewValue }: DateInput) 
         <img className="calendar-icon-img" src="/assets/icons/icon-calendar-minimalistic.svg" alt="달력 불러오기" />
       </label>
       {isOpenCalendar && (
-        <div className="calendar-popup-box">
+        <div className="calendar-popup-box" ref={calendarRef}>
           <Calendar
             onChange={handleDateChange} // 날짜 클릭했을 때 동작하는 핸들러
             onChangeMonth={handleMonthChange}

--- a/src/pages/AddSpace/comnponents/Schdules/DateInput/style.scss
+++ b/src/pages/AddSpace/comnponents/Schdules/DateInput/style.scss
@@ -24,4 +24,10 @@
 
 .calendar-input {
   width: 100%;
+  &:focus {
+    outline: none;
+  }
+  &:active {
+    border: 2px solid black;
+  }
 }

--- a/src/pages/AddSpace/comnponents/Schdules/TimeDropdown/index.tsx
+++ b/src/pages/AddSpace/comnponents/Schdules/TimeDropdown/index.tsx
@@ -1,7 +1,7 @@
-import { DropDown, DropdownItem } from '@/components/Dropdown';
+import { DropDown, DropDownValue, DropdownItem } from '@/components/Dropdown';
 
 interface TimeDropdownProps {
-  onClick: (value: string) => void;
+  onClick: (value: DropDownValue) => void;
 }
 
 export default function TimeDropdown({ onClick }: TimeDropdownProps) {

--- a/src/pages/AddSpace/comnponents/Schdules/index.tsx
+++ b/src/pages/AddSpace/comnponents/Schdules/index.tsx
@@ -6,6 +6,7 @@ import TimeDropdown from './TimeDropdown';
 
 import toast from '@/utils/toast';
 import { compareTime, isNonOverlappingSchedule } from '@/utils/compareTime';
+import { DropDownValue } from '@/components/Dropdown';
 
 interface SchedulesProps {
   schedules: Schedule[];
@@ -15,12 +16,16 @@ interface SchedulesProps {
 export default function Schedules({ schedules, setSchedules }: SchedulesProps) {
   const [inputValue, setInputValue] = useState<Schedule>({ date: '', startTime: '00:00', endTime: '00:00' });
 
-  const handleStartTime = (value: string) => {
-    setInputValue((prev) => ({ ...prev, startTime: value }));
+  const handleStartTime = (value: DropDownValue) => {
+    if (typeof value === 'string') {
+      setInputValue((prev) => ({ ...prev, startTime: value }));
+    }
   };
 
-  const handleEndTime = (value: string) => {
-    setInputValue((prev) => ({ ...prev, endTime: value }));
+  const handleEndTime = (value: DropDownValue) => {
+    if (typeof value === 'string') {
+      setInputValue((prev) => ({ ...prev, endTime: value }));
+    }
   };
 
   const handleScheduleButton = () => {

--- a/src/pages/AddSpace/comnponents/Schdules/style.scss
+++ b/src/pages/AddSpace/comnponents/Schdules/style.scss
@@ -11,13 +11,19 @@
 
   input {
     display: flex;
-    border: 1px solid var(--gray60, #79747e);
+    border: 1px solid var(--gray50);
     width: 100%;
     height: 100%;
     padding: 8px 16px;
     border-radius: 4px;
     justify-content: center;
     align-items: center;
+    &:focus {
+      outline: none;
+    }
+    &:active {
+      border: 2px solid black;
+    }
   }
 }
 
@@ -111,8 +117,13 @@
     width: 140px;
   }
   .dropdown-select {
+    border: 1px solid var(--gray50);
+    box-shadow: 0 0 0 0;
     height: 100%;
     justify-content: center;
+    &:active {
+      border: 2px solid black;
+    }
   }
   .dropdown-list {
     max-height: 300px;

--- a/src/pages/MySpaceManagement/components/MySpaceCard/index.tsx
+++ b/src/pages/MySpaceManagement/components/MySpaceCard/index.tsx
@@ -1,13 +1,13 @@
 import { Link, useNavigate } from 'react-router-dom';
 import { MySpaceCardProps } from '../../types';
 import './style.scss';
-import { DropDown, DropdownItem } from '@/components/Dropdown';
+import { DropDown, DropDownValue, DropdownItem } from '@/components/Dropdown';
 import { useModal } from '@/hooks/useModal/useModal';
 import DeleteModal from '@/pages/SpaceDetails/Components/DeleteModal';
 
 export default function MySpaceCard({ activity }: MySpaceCardProps) {
   const navigate = useNavigate();
-  const handleDropdown = (value: string) => {
+  const handleDropdown = (value: DropDownValue) => {
     switch (value) {
       case 'delete':
         openModal('delete');

--- a/src/pages/MySpaceManagement/components/MySpaceList/style.scss
+++ b/src/pages/MySpaceManagement/components/MySpaceList/style.scss
@@ -2,6 +2,9 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
+  @media (min-width: 1024px) {
+    gap: 24px;
+  }
 }
 
 .not-found-file-box {


### PR DESCRIPTION
## 주요 변경 사항

- 이제 수정 페이지 및 생성 페이지에서 캘린더가 열린 채 외부를 클릭하면 닫힙니다
- css form input 에 태두리색을 gray50으로 통일했습니다, active를 통일했습니다, focus 효과를 모두 삭제했습니다
- 타입오류를 수정했습니다
- 카테고리 드롭다운에 이모지를 추가했습니다
- 진아님이 이전에 말씀하신 카드 gap 1024px이상화면일때 더 넓게 24px로 조정했습니다!


## 리뷰어에게

- 정신없이 커밋해서 겸사겸사 css맞춘거라 css가 많이 산만해요!
- 화이팅!
- 
