### PR TITLE
[Fix] 스케줄을 비교해주는 util함수 수정 및 css 수정

### DIFF
--- a/src/pages/AddSpace/components/AddPlaceForm/index.tsx
+++ b/src/pages/AddSpace/components/AddPlaceForm/index.tsx
@@ -56,6 +56,11 @@ export default function AddPlaceForm() {
         />
         <span className="input-title">소개 이미지</span>
         <ImageUploader id="subImages" images={subimages} setImages={setSubImages} maxImageCount={4} />
+        <div className="form-button-bottom-box">
+          <Button className="form-button-bottom button-black" type="submit" disabled={isSubmitting}>
+            등록하기
+          </Button>
+        </div>
       </section>
     </form>
   );

--- a/src/pages/AddSpace/components/AddPlaceForm/style.scss
+++ b/src/pages/AddSpace/components/AddPlaceForm/style.scss
@@ -43,10 +43,21 @@
   justify-content: center;
   align-items: center;
   border-radius: 4px;
-  background: var(--black20, #1b1b1b);
-  color: var(--white, #fff);
   font-size: 1.6rem;
   cursor: pointer;
+}
+
+.form-button-bottom-box {
+  display: flex;
+  justify-content: center;
+}
+
+.form-button-bottom {
+  width: 300px;
+  height: 48px;
+  @media (min-width: 1024px) {
+    width: 400px;
+  }
 }
 
 .form-content {

--- a/src/pages/AddSpace/components/AddPlaceForm/style.scss
+++ b/src/pages/AddSpace/components/AddPlaceForm/style.scss
@@ -1,3 +1,17 @@
+.form-input,
+.form-textarea,
+.calendar-input,
+.place-form-box .dropdown-title,
+.place-form-box .dropdown-item,
+.set-date,
+.set-start-time,
+.set-end-time {
+  font-size: 1.4rem;
+  @media (min-width: 768px) {
+    font-size: 1.6rem;
+  }
+}
+
 .place-form-box {
   width: 344px;
   margin: 0 auto;

--- a/src/pages/AddSpace/components/Schdules/DateInput/style.scss
+++ b/src/pages/AddSpace/components/Schdules/DateInput/style.scss
@@ -15,11 +15,17 @@
 }
 
 .calendar-icon-img {
+  width: 20px;
+  height: 20px;
   position: absolute;
   right: 10px;
   top: 50%;
   transform: translateY(-50%);
   cursor: pointer;
+  @media (min-width: 768px) {
+    width: 28px;
+    height: 28px;
+  }
 }
 
 .calendar-input {

--- a/src/pages/AddSpace/components/Schdules/index.tsx
+++ b/src/pages/AddSpace/components/Schdules/index.tsx
@@ -78,6 +78,7 @@ export default function Schedules({ schedules, setSchedules }: SchedulesProps) {
               </button>
             </li>
           ))}
+          <div className="schduled-time-title">추가된 시간</div>
         </ul>
       )}
     </div>

--- a/src/pages/AddSpace/components/Schdules/style.scss
+++ b/src/pages/AddSpace/components/Schdules/style.scss
@@ -83,8 +83,11 @@
 
 .set-schedules-box {
   display: flex;
-  flex-direction: column;
+  flex-direction: column-reverse;
   gap: 8px;
+  max-height: 300px;
+  overflow: auto;
+  scrollbar-width: none;
 }
 
 .set-start-time,

--- a/src/pages/AddSpace/components/Schdules/style.scss
+++ b/src/pages/AddSpace/components/Schdules/style.scss
@@ -70,6 +70,15 @@
   }
 }
 
+.schduled-time-title {
+  color: var(--gray70, #4b4b4b);
+  font-size: 1.6rem;
+  font-weight: 500;
+  @media (min-width: 768px) {
+    font-size: 2rem;
+  }
+}
+
 .button-with-image {
   border: none;
   background: none;
@@ -85,7 +94,7 @@
   display: flex;
   flex-direction: column-reverse;
   gap: 8px;
-  max-height: 300px;
+  max-height: 280px;
   overflow: auto;
   scrollbar-width: none;
 }

--- a/src/pages/EditSpace/index.tsx
+++ b/src/pages/EditSpace/index.tsx
@@ -7,6 +7,7 @@ import CategoryDropdown from '../AddSpace/components/CategoryDropdown';
 import Schedules from '../AddSpace/components/Schdules';
 import './styles.scss';
 import useEditSpaceForm from '@/hooks/useEditSpaceForm';
+import Button from '@/components/Button';
 
 export default function EditSpace() {
   const {
@@ -32,7 +33,7 @@ export default function EditSpace() {
   return (
     <form className="place-form-box" onSubmit={handleSubmit(onSubmit, onError)}>
       <div className="form-header">
-        <h1 className="edit-space-title">편집하기</h1>
+        <h1 className="edit-space-title">수정하기</h1>
         <button className="form-button button-black" type="submit" disabled={isSubmitting}>
           등록하기
         </button>
@@ -56,6 +57,11 @@ export default function EditSpace() {
         />
         <span className="input-title">소개 이미지</span>
         <ImageUploader id="subImages" images={subimages} setImages={setSubImages} maxImageCount={4} />
+        <div className="form-button-bottom-box">
+          <Button className="form-button-bottom button-black" type="submit" disabled={isSubmitting}>
+            수정하기
+          </Button>
+        </div>
       </section>
     </form>
   );

--- a/src/pages/MySpaceManagement/components/MySpaceCard/index.tsx
+++ b/src/pages/MySpaceManagement/components/MySpaceCard/index.tsx
@@ -37,7 +37,7 @@ export default function MySpaceCard({ activity }: MySpaceCardProps) {
             </div>
             <div className="my-space-card-price">
               <span>
-                ￦{formattedPrice} <span className="price-person">/인</span>
+                ￦ {formattedPrice} <span className="price-person">/인</span>
               </span>
               <DropDown id="kabab" image="/assets/icons/icon-meatball.svg" onClickItem={handleDropdown}>
                 <DropdownItem value="edit">수정하기</DropdownItem>

--- a/src/utils/compareTime.ts
+++ b/src/utils/compareTime.ts
@@ -16,7 +16,7 @@ export function compareTime(startTime: string, endTime: string): boolean {
 export function isNonOverlappingSchedule(existingSchedules: Schedule[], newSchedule: Schedule): boolean {
   // 새로운 스케줄의 시작시간과 종료시간을 추출합니다.
   const { startTime: newStartTime, endTime: newEndTime, date: newDate } = newSchedule;
-
+  console.log(existingSchedules);
   // 기존 스케줄들을 순회하면서 겹치는 시간이 있는지 확인합니다.
   for (const existingSchedule of existingSchedules) {
     // 기존 스케줄의 시작시간과 종료시간을 추출합니다.
@@ -24,9 +24,9 @@ export function isNonOverlappingSchedule(existingSchedules: Schedule[], newSched
 
     // 새로운 스케줄과 비교할 날짜가 기존 스케줄 중 첫 번째 스케줄의 날짜와 같은지 확인합니다.
     if (newDate !== existingDate) {
-      return true;
+      console.log('데이트 안겹침');
+      continue;
     }
-
     // 겹치는 시간이 있는지 확인합니다.
     if (
       (newStartTime >= existingStartTime && newStartTime < existingEndTime) || // 새로운 시작시간이 기존 스케줄 사이에 있는 경우
@@ -37,7 +37,6 @@ export function isNonOverlappingSchedule(existingSchedules: Schedule[], newSched
       return false;
     }
   }
-
-  // 겹치는 시간이 없으면 true를 반환합니다.
   return true;
+  // 겹치는 시간이 없으면 true를 반환합니다.
 }

--- a/src/utils/compareTime.ts
+++ b/src/utils/compareTime.ts
@@ -16,7 +16,6 @@ export function compareTime(startTime: string, endTime: string): boolean {
 export function isNonOverlappingSchedule(existingSchedules: Schedule[], newSchedule: Schedule): boolean {
   // 새로운 스케줄의 시작시간과 종료시간을 추출합니다.
   const { startTime: newStartTime, endTime: newEndTime, date: newDate } = newSchedule;
-  console.log(existingSchedules);
   // 기존 스케줄들을 순회하면서 겹치는 시간이 있는지 확인합니다.
   for (const existingSchedule of existingSchedules) {
     // 기존 스케줄의 시작시간과 종료시간을 추출합니다.

--- a/src/utils/compareTime.ts
+++ b/src/utils/compareTime.ts
@@ -24,7 +24,6 @@ export function isNonOverlappingSchedule(existingSchedules: Schedule[], newSched
 
     // 새로운 스케줄과 비교할 날짜가 기존 스케줄 중 첫 번째 스케줄의 날짜와 같은지 확인합니다.
     if (newDate !== existingDate) {
-      console.log('데이트 안겹침');
       continue;
     }
     // 겹치는 시간이 있는지 확인합니다.


### PR DESCRIPTION
## 주요 변경 사항

- 스케줄이 중복을 검사해주는 유틸함수를 수정했습니다
- 추가하기 편집하기 페이지의 폰트 크기를 올렸고 추가한 스캐줄이 위에서부터 새로 쌓이게 바꾸었습니다
- 관리 페이지 카드 안 원화와 숫자 간격을 줬습니다
## 관련 이슈

- 스캐줄을 맥스 height 이상으로 추가했을 경우 새로 스캐줄을 추가할 시 스크롤바가 가장 위에 있는게 아니라 새로 추가하기 전의 최신 스캐줄 위치를 잡아 주어 추가된 새로운 스캐줄이 바로 안보이는 문제 발생!


## 리뷰어에게

- 화이팅!

