### PR TITLE
[Fix] 예약현황 페이지 드롭다운 상태값 수정

### DIFF
--- a/src/api/reservationStatusApi.ts
+++ b/src/api/reservationStatusApi.ts
@@ -13,7 +13,7 @@ export const reservationStatusApi = createApi({
   baseQuery: axiosBaseQuery({ baseUrl: BASE_URL }), // API의 기본 URL 설정
   reducerPath: 'reservationStatusApi',
   refetchOnMountOrArgChange: true, // 컴포넌트가 마운트되거나 매개변수가 변경될 때마다 새로고침
-  tagTypes: ['Reservation'],
+  tagTypes: ['Reservation', 'Schedule'],
   // 각각의 query/mutation 동작을 여기서 정의합니다.
   endpoints: (builder) => ({
     getActivityList: builder.query<MyActivities, void>({
@@ -28,6 +28,7 @@ export const reservationStatusApi = createApi({
     getReservedSchedule: builder.query<ReservedSchedule[], ReservationScheduleParams>({
       query: (schedule) =>
         `my-activities/${schedule.activityId}/reserved-schedule?date=${format(schedule.date, 'yyyy-MM-dd')}`, // 내 체험 날짜별 예약 정보 조회 엔드포인트
+      providesTags: ['Schedule'],
     }),
     getTimeReservations: builder.query<TimeReservationList, TimeReservationParams>({
       query: ({ activityId, scheduleId, status }) =>
@@ -41,7 +42,7 @@ export const reservationStatusApi = createApi({
         body: { status },
         method: 'PATCH',
       }),
-      invalidatesTags: ['Reservation'],
+      invalidatesTags: ['Reservation', 'Schedule'],
     }),
   }),
 });

--- a/src/components/Calendar/components/ReservationInformation.tsx
+++ b/src/components/Calendar/components/ReservationInformation.tsx
@@ -7,11 +7,11 @@ import { DropDown, DropDownValue, DropdownItem } from '@/components/Dropdown';
 import { useModal } from '@/hooks/useModal/useModal';
 import ErrorModal from '@/pages/ErrorModal';
 import { translateMap } from '@/utils/calendarUtils';
+import toast from '@/utils/toast';
 import { format } from 'date-fns';
 import { useEffect, useRef, useState } from 'react';
 import Button from '../../Button';
 import './reservationInformation.scss';
-import toast from '@/utils/toast';
 
 export default function ReservationInformation({ chip, selectedDate, activityId }: ReservationInformationProps) {
   const [selectedTab, setSelectedTab] = useState<UpdateReservationStatus>(

--- a/src/components/Calendar/components/ReservationInformation.tsx
+++ b/src/components/Calendar/components/ReservationInformation.tsx
@@ -14,6 +14,7 @@ import Button from '../../Button';
 import './reservationInformation.scss';
 
 export default function ReservationInformation({ chip, selectedDate, activityId }: ReservationInformationProps) {
+  const [selectedScheduleId, setSelectedScheduleId] = useState<number>();
   const [selectedTab, setSelectedTab] = useState<UpdateReservationStatus>(
     chip === 'completed' ? 'pending' : chip ?? 'pending',
   ); // 예약 상태 선택
@@ -25,10 +26,12 @@ export default function ReservationInformation({ chip, selectedDate, activityId 
   };
 
   const handleTabClick = (tab: UpdateReservationStatus) => {
+    setSelectedScheduleId(undefined);
     setSelectedTab(tab);
   };
 
   const onClickTimeItem = (scheduleId: DropDownValue) => {
+    setSelectedScheduleId(scheduleId as number);
     getTimeReservations({
       activityId,
       scheduleId: scheduleId as number,
@@ -82,6 +85,7 @@ export default function ReservationInformation({ chip, selectedDate, activityId 
               arrowUp={'∧'}
               arrowDown={'∨'}
               onClickItem={onClickTimeItem}
+              value={selectedScheduleId}
             >
               {scheduleList
                 ?.filter((schedule) => schedule.count[selectedTab] > 0)
@@ -108,7 +112,6 @@ export default function ReservationInformation({ chip, selectedDate, activityId 
               <div className="reservation-information-top" onClick={scrollToTop}>
                 <img src="/assets/icons/icon-top.gif" alt="위로 가기" />
               </div>
-              {totalCount > 1 && <div className="shadow-box"></div>}
             </div>
           )}
         </div>

--- a/src/components/Calendar/components/reservationInformation.scss
+++ b/src/components/Calendar/components/reservationInformation.scss
@@ -21,7 +21,7 @@
   display: flex;
   flex-direction: column;
   gap: 20px;
-  background-color: var(--gray10);
+  background-color: var(--white);
   border-bottom: 1px solid var(--gray30);
   border-left: 1px solid var(--gray30);
   border-right: 1px solid var(--gray30);
@@ -115,32 +115,26 @@ div.active {
   gap: 10px;
   height: 165px;
   overflow-y: scroll;
-  scrollbar-width: none;
-  ::-webkit-scrollbar {
-    display: none;
-    width: 0px;
+  scrollbar-width: 2px;
+  padding: 0 5px;
+
+  &::-webkit-scrollbar {
+    width: 5px;
+    background-color: var(--gray10);
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: var(--gray20);
+    border-radius: 10px;
   }
 
   @media screen and (min-width: 768px) {
     height: 200px;
   }
 
-  .shadow-box {
-    position: absolute;
-    width: 219px;
-    height: 30px;
-    bottom: 25px;
-    background: linear-gradient(to top, var(--gray20), transparent);
-
-    @media screen and (min-width: 768px) {
-      width: 379px;
-    }
-  }
-
   .reservation-information-top {
     display: flex;
     justify-content: center;
-    margin: 10px 0 30px;
 
     img {
       cursor: pointer;
@@ -169,7 +163,7 @@ div.active {
 .reservation-information-content-booking-history {
   width: 100%;
   height: 175px;
-  background-color: var(--white);
+  background-color: #fcfcfc;
   border: 1px solid var(--gray30);
   border-radius: 10px;
   padding: 20px 10px;

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useEffect, useRef, useState } from 'react';
 import './style.scss';
 
-interface DropDwonProps {
+interface DropDownProps {
   id: string;
   title?: string;
   image?: string;
@@ -9,6 +9,7 @@ interface DropDwonProps {
   arrowDown?: string;
   children: React.ReactNode;
   onClickItem?: (value: DropDownValue, id: string) => void;
+  value?: DropDownValue;
 }
 
 interface DropdownItem {
@@ -25,9 +26,10 @@ interface DropdownContextProps {
 
 export const DropdownContext = createContext<DropdownContextProps>({});
 
-export const DropDown = (props: DropDwonProps) => {
+export const DropDown = (props: DropDownProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const [select, setSelect] = useState<React.ReactNode | null>(null);
+  const [select, setSelect] = useState<React.ReactNode>();
+  const [selectedValue, setSelectedValue] = useState<DropDownValue>();
 
   const dropDownRef = useRef<HTMLDivElement>(null);
 
@@ -50,13 +52,13 @@ export const DropDown = (props: DropDwonProps) => {
   }, []);
 
   // 드롭다운 props
-  const title = props.title;
-  const image = props.image;
-  const arrowUp = props.arrowUp;
-  const arrowDown = props.arrowDown;
-  const array = props.children;
-  const id = props.id;
-  const onClickItem = props.onClickItem;
+  const { title, image, arrowUp, arrowDown, children: array, id, onClickItem, value } = props;
+
+  useEffect(() => {
+    if (selectedValue != value) {
+      setSelect(null);
+    }
+  }, [value]);
 
   // 드롭다운 셀렉터 보여주는 함수
   const handleShowTitle = () => {
@@ -87,6 +89,7 @@ export const DropDown = (props: DropDwonProps) => {
   // 드롭다운 클릭시 실행 함수
   const handleClickItem = (children: React.ReactNode, value: DropDownValue) => {
     setSelect(children);
+    setSelectedValue(value);
     onClickItem?.(value, id);
   };
 

--- a/src/pages/ReservationStatus/index.tsx
+++ b/src/pages/ReservationStatus/index.tsx
@@ -14,11 +14,11 @@ import './style.scss';
 export default function ReservationStatus() {
   const { Calendar, selectedDate, setSelectedDate } = useCalendar();
   const { data: myActivities, ...myActivitiesQuery } = useGetActivityListQuery(); // 내 체험 리스트 조회
-  const [activityId, setActivityId] = useState<number | undefined>(); // 체험명 선택
+  const [activityId, setActivityId] = useState<number>(); // 체험명 선택
   const [selectedChip, setSelectedChip] = useState<ReservationChip>('pending'); // 예약 상태 선택
   const [getReservationDashboard, { data: myDashboard, ...myDashboardQuery }] = useLazyGetReservationDashboardQuery();
   const { Modal, openModal, closeModal } = useModal();
-  const [selectedActivity, setSelectedActivity] = useState<string>('');
+  const [selectedActivity, setSelectedActivity] = useState<string>();
 
   const isError = myActivitiesQuery.isError || myDashboardQuery.isError;
   const isLoading =

--- a/src/pages/ReservationStatus/index.tsx
+++ b/src/pages/ReservationStatus/index.tsx
@@ -18,6 +18,7 @@ export default function ReservationStatus() {
   const [selectedChip, setSelectedChip] = useState<ReservationChip>('pending'); // 예약 상태 선택
   const [getReservationDashboard, { data: myDashboard, ...myDashboardQuery }] = useLazyGetReservationDashboardQuery();
   const { Modal, openModal, closeModal } = useModal();
+  const [selectedActivity, setSelectedActivity] = useState<string>('');
 
   const isError = myActivitiesQuery.isError || myDashboardQuery.isError;
   const isLoading =
@@ -38,6 +39,7 @@ export default function ReservationStatus() {
     myActivities?.activities.forEach((activity) => {
       if (activity.title === value) {
         setActivityId(activity.id);
+        setSelectedActivity(value);
       }
     }, []);
   };
@@ -80,7 +82,7 @@ export default function ReservationStatus() {
             {/* 내 체험 리스트 조회 */}
             <DropDown
               id="activityNames"
-              title={'체험을 선택해주세요.'}
+              title={selectedActivity || '체험을 선택해주세요.'}
               arrowUp={'∧'}
               arrowDown={'∨'}
               onClickItem={onClickItem}


### PR DESCRIPTION
## 이슈 번호

#25 

## 주요 변경 사항

- 예약현황 페이지 드롭다운 타이틀 클릭 시 타이틀 상태값 유지
- 예약현황 모달 내 시간 드롭다운 값이 바뀌면 초기화되도록 수정
- 선영님이 만드신 Dropdown 컴포넌트에 선택값 useState 훅을 추가해서 상태를 확인할 수 있게 수정했습니다.
- 모달 디자인을 살짝 수정했습니다!

## 관련 스크린샷

![2024-05-09 00;18;06](https://github.com/Sprint3-6/yeogiya/assets/113954463/a347c8a1-b47e-4a5d-a18c-72aded793e15)

## 리뷰어에게

- 무한스크롤은 진짜 내일 ...! 굿밤 행밤 😊
