### PR TITLE
[Design] base, mypagelayouy, edit, addspace 등 페이지 css 수정

### DIFF
--- a/src/pages/AddSpace/components/AddPlaceForm/index.tsx
+++ b/src/pages/AddSpace/components/AddPlaceForm/index.tsx
@@ -56,6 +56,7 @@ export default function AddPlaceForm() {
         />
         <span className="input-title">소개 이미지</span>
         <ImageUploader id="subImages" images={subimages} setImages={setSubImages} maxImageCount={4} />
+        <span className="image-span">*이미지는 최대 4개까지 등록이 가능합니다</span>
         <div className="form-button-bottom-box">
           <Button className="form-button-bottom button-black" type="submit" disabled={isSubmitting}>
             등록하기

--- a/src/pages/AddSpace/components/AddPlaceForm/style.scss
+++ b/src/pages/AddSpace/components/AddPlaceForm/style.scss
@@ -145,3 +145,7 @@ input::-webkit-inner-spin-button {
     font-size: 2.4rem;
   }
 }
+
+.image-span {
+  font-size: 1.8rem;
+}

--- a/src/pages/AddSpace/components/ImageUploader/style.scss
+++ b/src/pages/AddSpace/components/ImageUploader/style.scss
@@ -29,7 +29,14 @@
 }
 
 .delete-image {
+  width: 32px;
+  height: 32px;
   position: absolute;
-  top: 0;
-  right: 0;
+  top: -16px;
+  right: -16px;
+  cursor: pointer;
+  @media (min-width: 768px) {
+    width: 40px;
+    height: 40px;
+  }
 }

--- a/src/pages/EditSpace/index.tsx
+++ b/src/pages/EditSpace/index.tsx
@@ -57,6 +57,7 @@ export default function EditSpace() {
         />
         <span className="input-title">소개 이미지</span>
         <ImageUploader id="subImages" images={subimages} setImages={setSubImages} maxImageCount={4} />
+        <span className="image-span">*이미지는 최대 4개까지 등록이 가능합니다</span>
         <div className="form-button-bottom-box">
           <Button className="form-button-bottom button-black" type="submit" disabled={isSubmitting}>
             수정하기

--- a/src/pages/EditSpace/styles.scss
+++ b/src/pages/EditSpace/styles.scss
@@ -150,3 +150,7 @@ input::-webkit-inner-spin-button {
     font-size: 2.4rem;
   }
 }
+
+.image-span {
+  font-size: 1.8rem;
+}

--- a/src/pages/MySpaceManagement/components/MySpaceCard/style.scss
+++ b/src/pages/MySpaceManagement/components/MySpaceCard/style.scss
@@ -95,6 +95,7 @@
 .my-space-card-img {
   width: 100%;
   height: 100%;
+  object-fit: cover;
 }
 
 .my-space-card-price {

--- a/src/pages/MySpaceManagement/components/MySpaceCard/style.scss
+++ b/src/pages/MySpaceManagement/components/MySpaceCard/style.scss
@@ -2,6 +2,7 @@
   display: flex;
   width: 100%;
   height: 128px;
+  background-color: var(--white);
   border-radius: 24px;
   box-shadow:
     0 1px 3px rgba(0, 0, 0, 0.12),

--- a/src/routes/mypagelayout/style.scss
+++ b/src/routes/mypagelayout/style.scss
@@ -2,6 +2,7 @@ sub {
   display: flex;
   flex-direction: column;
   margin-top: 24px;
+  margin-bottom: 24px;
   @media (min-width: 768px) {
     flex-direction: row;
     justify-content: center;

--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -53,7 +53,6 @@ html {
 body {
   font-family: 'Pretendard Variable', sans-serif;
   height: 100%;
-  overflow: hidden;
   padding: 0;
   font-size: 1.6rem;
 }
@@ -84,7 +83,6 @@ input {
   display: flex;
   height: 100%;
   flex-direction: column;
-  overflow-y: auto;
 }
 
 ::-webkit-scrollbar {


### PR DESCRIPTION
## 주요 변경 사항

- base css 에 있던 필요 없어 보이는 overflow 값들을 삭제했습니다
- mypagelayout쪽 바텀에 마진을 주었습니다
- add,edit, 페이지의 이미지 삭제 버튼 크기와 위치를 조정했습니다, 이미지추가 아래에 문구를 추가했습니다
- 내 공간 관리 페이지의 랜더링되는 카드들 배경색을 흰색으로 넣어주었습니다


## 리뷰어에게

- 화이팅!


