### PR TITLE
[Design] 작은 캘린더에 padding 추가

### DIFF
--- a/src/components/Calendar/style.scss
+++ b/src/components/Calendar/style.scss
@@ -11,6 +11,7 @@
 .calendar-small {
   width: fit-content;
   border: 1px solid var(--gray30);
+  padding: 10px 10px;
 }
 
 .calendar-large {


### PR DESCRIPTION
## 주요 변경 사항

- 어제 캘린더 디자인 변경하면서 작은 캘린더도 padding이 사라진 이슈 발견 후 수정

## 관련 스크린샷

![2024-05-14 11;45;56](https://github.com/Sprint3-6/yeogiya/assets/113954463/7682caba-6e2c-492d-9c24-9581cc3ff4d5)

## 리뷰어에게
- 맛점 🥄
